### PR TITLE
Update base image to eclipse-temurin and Spring Boot to 3.5.15

### DIFF
--- a/examples/binance-websocket/Dockerfile
+++ b/examples/binance-websocket/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/binance-websocket/build.gradle
+++ b/examples/binance-websocket/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '3.5.15'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/examples/kafka-basic/Dockerfile
+++ b/examples/kafka-basic/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/kafka-basic/build.gradle
+++ b/examples/kafka-basic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '3.5.15'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/examples/kafka-streams/Dockerfile
+++ b/examples/kafka-streams/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/kafka-streams/build.gradle
+++ b/examples/kafka-streams/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '3.5.15'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/variants/mvc-jpa/template/Dockerfile
+++ b/variants/mvc-jpa/template/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE __APP_PORT__ __MANAGEMENT_PORT__

--- a/variants/mvc-jpa/template/build.gradle
+++ b/variants/mvc-jpa/template/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '3.5.15'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.cyclonedx.bom' version '3.2.4'
 }

--- a/variants/webflux-r2dbc/template/Dockerfile
+++ b/variants/webflux-r2dbc/template/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21-jre-ubi10-minimal
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE __APP_PORT__ __MANAGEMENT_PORT__

--- a/variants/webflux-r2dbc/template/build.gradle
+++ b/variants/webflux-r2dbc/template/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.14'
+    id 'org.springframework.boot' version '3.5.15'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.cyclonedx.bom' version '3.2.4'
 }


### PR DESCRIPTION
This pull request updates several example and template projects to use newer versions of both the base Docker image and the Spring Boot plugin. The main changes are version bumps for improved security and compatibility.

Dependency updates:

* Upgraded `org.springframework.boot` plugin from version `3.5.14` to `3.5.15` in all affected `build.gradle` files for `binance-websocket`, `kafka-basic`, `kafka-streams`, `mvc-jpa`, and `webflux-r2dbc` projects. [[1]](diffhunk://#diff-e9a75fe139a3966ab17552618ab7afc7d059e824662e33a1f368b3baf60e0882L3-R3) [[2]](diffhunk://#diff-e582b253f56d265f56df5512b0862241fd8098b80c3ce73f2b95d6fea1bcdf68L3-R3) [[3]](diffhunk://#diff-8711b034e56da97731a13cfb840dfd292d3229811d1151d6e9e9f5dd633a9e32L3-R3) [[4]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eL4-R4) [[5]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eL4-R4)

Docker base image updates:

* Changed the Docker base image from `eclipse-temurin:21-jre-ubi10-minimal` to `eclipse-temurin:21.0.11_10-jre-alpine-3.21` in all corresponding `Dockerfile`s, which impacts the runtime environment for all example and template services. [[1]](diffhunk://#diff-0c0442f96ba5546d8f5c04162be4c45c4f4669b6201ed1e88ee6a83dab84da61L8-R8) [[2]](diffhunk://#diff-dd8ff1daec8fd8c685cb6e5a27e449516003a8ee394f0eeae2d948b3d0ef4fcaL8-R8)