### PR TITLE
Update base image and dependencies in Dockerfiles and examples

### DIFF
--- a/examples/binance-websocket/Dockerfile
+++ b/examples/binance-websocket/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.22
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/binance-websocket/Dockerfile
+++ b/examples/binance-websocket/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:9.4.1-jdk21 AS builder
+FROM gradle:9.5.1-jdk21 AS builder
 WORKDIR /usr/src/app
 COPY src ./src
 COPY build.gradle .

--- a/examples/binance-websocket/build.gradle
+++ b/examples/binance-websocket/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.kafka:spring-kafka'
-    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
-    implementation 'io.github.resilience4j:resilience4j-reactor:2.3.0'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.4.0'
+    implementation 'io.github.resilience4j:resilience4j-reactor:2.4.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/examples/kafka-basic/Dockerfile
+++ b/examples/kafka-basic/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.22
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/kafka-basic/Dockerfile
+++ b/examples/kafka-basic/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:9.4.1-jdk21 AS builder
+FROM gradle:9.5.1-jdk21 AS builder
 WORKDIR /usr/src/app
 COPY src ./src
 COPY build.gradle .

--- a/examples/kafka-streams/Dockerfile
+++ b/examples/kafka-streams/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.22
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE 8080

--- a/examples/kafka-streams/Dockerfile
+++ b/examples/kafka-streams/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:9.4.1-jdk21 AS builder
+FROM gradle:9.5.1-jdk21 AS builder
 WORKDIR /usr/src/app
 COPY src ./src
 COPY build.gradle .

--- a/variants/mvc-jpa/template/Dockerfile
+++ b/variants/mvc-jpa/template/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.22
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE __APP_PORT__ __MANAGEMENT_PORT__

--- a/variants/webflux-r2dbc/template/Dockerfile
+++ b/variants/webflux-r2dbc/template/Dockerfile
@@ -5,7 +5,7 @@ COPY build.gradle .
 COPY settings.gradle .
 RUN gradle --no-daemon bootJar -x test
 
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.21
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.22
 WORKDIR /app
 COPY --from=builder /usr/src/app/build/libs/app.jar ./app.jar
 EXPOSE __APP_PORT__ __MANAGEMENT_PORT__


### PR DESCRIPTION
This pull request updates Docker base images and dependencies across several example projects and templates to use newer versions. The main changes include upgrading the Gradle and Eclipse Temurin base images in Dockerfiles, as well as updating the `resilience4j` dependencies in the Binance WebSocket example.

**Docker base image upgrades:**
- Upgraded Gradle builder image from `gradle:9.4.1-jdk21` to `gradle:9.5.1-jdk21` in `examples/binance-websocket/Dockerfile`, `examples/kafka-basic/Dockerfile`, and `examples/kafka-streams/Dockerfile`.
- Updated runtime image from `eclipse-temurin:21.0.11_10-jre-alpine-3.21` to `eclipse-temurin:21.0.11_10-jre-alpine-3.22` in all affected Dockerfiles, including `variants/mvc-jpa/template/Dockerfile` and `variants/webflux-r2dbc/template/Dockerfile`. [[1]](diffhunk://#diff-0c0442f96ba5546d8f5c04162be4c45c4f4669b6201ed1e88ee6a83dab84da61L1-R8) [[2]](diffhunk://#diff-dd8ff1daec8fd8c685cb6e5a27e449516003a8ee394f0eeae2d948b3d0ef4fcaL8-R8)

**Dependency version updates:**
- Upgraded `resilience4j-spring-boot3` and `resilience4j-reactor` from version `2.3.0` to `2.4.0` in `examples/binance-websocket/build.gradle`.