### PR TITLE
Update GitHub Actions for Gradle setup and enhance dependency logic

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,6 +11,41 @@ on:
     branches: ["main", "dev"]
 
 jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - examples/kafka-basic
+          - examples/kafka-streams
+          - examples/binance-websocket
+          - variants/mvc-jpa/template
+          - variants/webflux-r2dbc/template
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle dependency submission
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          dependency-graph: generate-and-submit
+          dependency-graph-continue-on-failure: false
+
+      - name: Resolve runtime dependencies
+        run: ./gradlew -p "${{ matrix.project }}" dependencies --configuration runtimeClasspath --no-daemon
+
+      - name: Resolve test dependencies
+        run: ./gradlew -p "${{ matrix.project }}" dependencies --configuration testRuntimeClasspath --no-daemon
+
   repository-checks:
     runs-on: ubuntu-latest
 
@@ -24,7 +59,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Validate repository root
         run: ./gradlew build --no-daemon
@@ -48,7 +83,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build example
         run: ./gradlew -p "examples/${{ matrix.example }}" build --no-daemon

--- a/.github/workflows/starter-validation.yml
+++ b/.github/workflows/starter-validation.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Generate starter
         run: |

--- a/examples/binance-websocket/build.gradle
+++ b/examples/binance-websocket/build.gradle
@@ -9,8 +9,7 @@ version = '0.1.0-SNAPSHOT'
 
 ext {
     set('kafka.version', '3.9.2')
-    set('netty.version', '4.1.133.Final')
-    set('testcontainersVersion', '1.21.3')
+    set('testcontainersVersion', '1.21.4')
 }
 
 java {
@@ -30,6 +29,12 @@ dependencyManagement {
 }
 
 dependencies {
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.28.0') {
+            because 'Testcontainers 1.21.x brings an older commons-compress version with published advisories'
+        }
+    }
+
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.kafka:spring-kafka'

--- a/variants/mvc-jpa/template/.github/workflows/ci.yml
+++ b/variants/mvc-jpa/template/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:
@@ -22,7 +22,10 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          dependency-graph: ${{ github.event_name == 'push' && 'generate-and-submit' || 'disabled' }}
+          dependency-graph-continue-on-failure: false
 
       - name: Run quality gates
         run: ./gradlew check --no-daemon

--- a/variants/mvc-jpa/template/.github/workflows/publish.yml
+++ b/variants/mvc-jpa/template/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Verify tag commit is on main
         run: |

--- a/variants/mvc-jpa/template/build.gradle
+++ b/variants/mvc-jpa/template/build.gradle
@@ -11,7 +11,7 @@ version = '0.1.0-SNAPSHOT'
 
 ext {
     set('postgresql.version', '42.7.11')
-    set('testcontainersVersion', '1.21.3')
+    set('testcontainersVersion', '1.21.4')
 }
 
 java {
@@ -31,6 +31,12 @@ dependencyManagement {
 }
 
 dependencies {
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.28.0') {
+            because 'Testcontainers 1.21.x brings an older commons-compress version with published advisories'
+        }
+    }
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/variants/webflux-r2dbc/template/.github/workflows/ci.yml
+++ b/variants/webflux-r2dbc/template/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:
@@ -22,7 +22,10 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          dependency-graph: ${{ github.event_name == 'push' && 'generate-and-submit' || 'disabled' }}
+          dependency-graph-continue-on-failure: false
 
       - name: Run quality gates
         run: ./gradlew check --no-daemon

--- a/variants/webflux-r2dbc/template/.github/workflows/publish.yml
+++ b/variants/webflux-r2dbc/template/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Verify tag commit is on main
         run: |

--- a/variants/webflux-r2dbc/template/build.gradle
+++ b/variants/webflux-r2dbc/template/build.gradle
@@ -10,9 +10,8 @@ group = '__GROUP_ID__'
 version = '0.1.0-SNAPSHOT'
 
 ext {
-    set('netty.version', '4.1.133.Final')
     set('postgresql.version', '42.7.11')
-    set('testcontainersVersion', '1.21.3')
+    set('testcontainersVersion', '1.21.4')
 }
 
 java {
@@ -32,6 +31,12 @@ dependencyManagement {
 }
 
 dependencies {
+    constraints {
+        testImplementation('org.apache.commons:commons-compress:1.28.0') {
+            because 'Testcontainers 1.21.x brings an older commons-compress version with published advisories'
+        }
+    }
+
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-validation'


### PR DESCRIPTION
This pull request introduces several improvements to dependency management and CI workflows across multiple modules and templates. The key changes include upgrading the `testcontainers` library version, enforcing a safer version of `commons-compress` due to security advisories, and updating GitHub Actions workflows to use newer Gradle actions and submit dependency graphs. Permissions for some workflows have also been updated to allow writing contents.

**Dependency management and security:**

* Upgraded `testcontainersVersion` to `1.21.4` in `build.gradle` files for `examples/binance-websocket`, `variants/mvc-jpa/template`, and `variants/webflux-r2dbc/template` to incorporate the latest fixes and improvements. [[1]](diffhunk://#diff-e9a75fe139a3966ab17552618ab7afc7d059e824662e33a1f368b3baf60e0882L12-R12) [[2]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eL14-R14) [[3]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eL13-R14)
* Added a `constraints` block to enforce `org.apache.commons:commons-compress:1.28.0` for `testImplementation`, mitigating advisories from older versions brought in by Testcontainers 1.21.x. [[1]](diffhunk://#diff-e9a75fe139a3966ab17552618ab7afc7d059e824662e33a1f368b3baf60e0882R32-R37) [[2]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eR34-R39) [[3]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eR34-R39)

**CI/CD workflow improvements:**

* Updated GitHub Actions workflows (`ci.yml`, `publish.yml`, `starter-validation.yml`, and `gradle.yml`) to use `gradle/actions/setup-gradle@v6` instead of v4, and enabled dependency graph generation and submission for push events. [[1]](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325L27-R62) [[2]](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325L51-R86) [[3]](diffhunk://#diff-5c862febf0224e3353f9c325aee56b94a896382937f63ef7437ff881507982d0L42-R42) [[4]](diffhunk://#diff-38603d32afbe7c835e27f832717322c7e0919450a3928a49c300d09dd4c46fbeL25-R28) [[5]](diffhunk://#diff-6dfd8053d9380f760ea5dc2008beaff8a822f543a3cb3dba26f09a3ad1370741L25-R25)
* Added a new `dependency-submission` job in `.github/workflows/gradle.yml` to generate and submit dependency graphs for several example and template projects.
* Updated workflow permissions from `contents: read` to `contents: write` where necessary to support dependency graph submission. [[1]](diffhunk://#diff-38603d32afbe7c835e27f832717322c7e0919450a3928a49c300d09dd4c46fbeL4-R4) [[2]](diffhunk://#diff-38603d32afbe7c835e27f832717322c7e0919450a3928a49c300d09dd4c46fbeL4-R4)

These changes enhance dependency security, improve build transparency, and modernize the CI/CD process.