### PR TITLE
Enhance GitHub Actions workflows and update Gradle for OpenTelemetry 1.62.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,13 +34,15 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Generate and submit runtime dependency graph
-        uses: gradle/actions/dependency-submission@v6
+      - name: Setup Gradle for dependency graph submission
+        uses: gradle/actions/setup-gradle@v6
         with:
-          build-root-directory: ${{ matrix.project }}
           dependency-graph: generate-and-submit
           dependency-graph-continue-on-failure: false
           dependency-graph-include-configurations: runtimeClasspath
+
+      - name: Resolve runtime dependencies
+        run: ./gradlew -p "${{ matrix.project }}" dependencies --configuration runtimeClasspath --no-daemon
 
   repository-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,17 +34,13 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Setup Gradle dependency submission
-        uses: gradle/actions/setup-gradle@v6
+      - name: Generate and submit runtime dependency graph
+        uses: gradle/actions/dependency-submission@v6
         with:
+          build-root-directory: ${{ matrix.project }}
           dependency-graph: generate-and-submit
           dependency-graph-continue-on-failure: false
-
-      - name: Resolve runtime dependencies
-        run: ./gradlew -p "${{ matrix.project }}" dependencies --configuration runtimeClasspath --no-daemon
-
-      - name: Resolve test dependencies
-        run: ./gradlew -p "${{ matrix.project }}" dependencies --configuration testRuntimeClasspath --no-daemon
+          dependency-graph-include-configurations: runtimeClasspath
 
   repository-checks:
     runs-on: ubuntu-latest

--- a/variants/mvc-jpa/template/.github/workflows/ci.yml
+++ b/variants/mvc-jpa/template/.github/workflows/ci.yml
@@ -23,9 +23,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Submit runtime dependency graph
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: gradle/actions/dependency-submission@v6
         with:
-          dependency-graph: ${{ github.event_name == 'push' && 'generate-and-submit' || 'disabled' }}
+          dependency-graph: generate-and-submit
           dependency-graph-continue-on-failure: false
+          dependency-graph-include-configurations: runtimeClasspath
 
       - name: Run quality gates
         run: ./gradlew check --no-daemon

--- a/variants/mvc-jpa/template/build.gradle
+++ b/variants/mvc-jpa/template/build.gradle
@@ -10,6 +10,7 @@ group = '__GROUP_ID__'
 version = '0.1.0-SNAPSHOT'
 
 ext {
+    set('opentelemetry.version', '1.62.0')
     set('postgresql.version', '42.7.11')
     set('testcontainersVersion', '1.21.4')
 }

--- a/variants/webflux-r2dbc/template/.github/workflows/ci.yml
+++ b/variants/webflux-r2dbc/template/.github/workflows/ci.yml
@@ -23,9 +23,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Submit runtime dependency graph
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
+        uses: gradle/actions/dependency-submission@v6
         with:
-          dependency-graph: ${{ github.event_name == 'push' && 'generate-and-submit' || 'disabled' }}
+          dependency-graph: generate-and-submit
           dependency-graph-continue-on-failure: false
+          dependency-graph-include-configurations: runtimeClasspath
 
       - name: Run quality gates
         run: ./gradlew check --no-daemon

--- a/variants/webflux-r2dbc/template/build.gradle
+++ b/variants/webflux-r2dbc/template/build.gradle
@@ -10,6 +10,7 @@ group = '__GROUP_ID__'
 version = '0.1.0-SNAPSHOT'
 
 ext {
+    set('opentelemetry.version', '1.62.0')
     set('postgresql.version', '42.7.11')
     set('testcontainersVersion', '1.21.4')
 }


### PR DESCRIPTION
This pull request updates the Gradle workflows and build files to improve dependency graph submission and keep dependency versions up to date. The main changes are focused on streamlining the GitHub Actions for dependency submission and updating the OpenTelemetry version in the Gradle build files.

**GitHub Actions workflow improvements:**

* Replaces the separate dependency resolution steps with the `gradle/actions/dependency-submission@v6` action in `.github/workflows/gradle.yml`, ensuring the runtime dependency graph is generated and submitted using the correct configuration.
* Updates both `variants/mvc-jpa/template/.github/workflows/ci.yml` and `variants/webflux-r2dbc/template/.github/workflows/ci.yml` to conditionally submit the runtime dependency graph only on branch pushes, using the new action and configuration.

**Dependency version updates:**

* Sets the `opentelemetry.version` property to `1.62.0` in both `variants/mvc-jpa/template/build.gradle` and `variants/webflux-r2dbc/template/build.gradle` to keep observability dependencies up to date. [[1]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eR13) [[2]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eR13)