### PR TITLE
Patch Gradle plugin classpath vulnerabilities

### DIFF
--- a/examples/binance-websocket/build.gradle
+++ b/examples/binance-websocket/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-lang3') {
+                details.useVersion '3.18.0'
+                details.because 'Avoid vulnerable commons-lang3 versions on the Gradle plugin classpath'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.15'

--- a/examples/kafka-basic/build.gradle
+++ b/examples/kafka-basic/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-lang3') {
+                details.useVersion '3.18.0'
+                details.because 'Avoid vulnerable commons-lang3 versions on the Gradle plugin classpath'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.15'

--- a/examples/kafka-streams/build.gradle
+++ b/examples/kafka-streams/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-lang3') {
+                details.useVersion '3.18.0'
+                details.because 'Avoid vulnerable commons-lang3 versions on the Gradle plugin classpath'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.15'

--- a/variants/mvc-jpa/template/build.gradle
+++ b/variants/mvc-jpa/template/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.codehaus.plexus' && details.requested.name == 'plexus-utils') {
+                details.useVersion '3.6.1'
+                details.because 'Avoid vulnerable plexus-utils versions on the Gradle plugin classpath'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'jacoco'

--- a/variants/webflux-r2dbc/template/build.gradle
+++ b/variants/webflux-r2dbc/template/build.gradle
@@ -1,3 +1,14 @@
+buildscript {
+    configurations.classpath {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.codehaus.plexus' && details.requested.name == 'plexus-utils') {
+                details.useVersion '3.6.1'
+                details.because 'Avoid vulnerable plexus-utils versions on the Gradle plugin classpath'
+            }
+        }
+    }
+}
+
 plugins {
     id 'java'
     id 'jacoco'


### PR DESCRIPTION
## Summary
- force patched commons-lang3 on the Gradle plugin classpath for example projects
- force patched plexus-utils on the Gradle plugin classpath for starter templates
- leave app runtime dependencies unchanged

## Validation
- ./.github/scripts/validate-repository.sh
- ./gradlew -p examples/kafka-basic build --no-daemon
- ./gradlew -p examples/kafka-streams build --no-daemon
- ./gradlew -p examples/binance-websocket build --no-daemon
- ./gradlew -p variants/mvc-jpa/template check -x test --no-daemon
- ./gradlew -p variants/webflux-r2dbc/template check -x test --no-daemon

Template tests were not run locally because Docker is not running; CI should run them with Testcontainers.