### PR TITLE
Upgrade to Spring Boot 4.1.0 and update dependencies and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format follows a simple keep-a-changelog style with concise user-visible ent
 ### Changed
 - Reposition repository from playground to Spring service starter
 - Add starter variants, examples scaffolding, bootstrap script, and Helm chart
-- Upgrade starter and example baseline to Spring Boot 3.5.13 and align Docker builder images on Gradle 9.4.1
+- Upgrade starter and example baseline to Spring Boot 4.1.0 and align Docker builder images on Gradle 9.6.1
 - Move starter integration tests to Spring Boot Testcontainers service connections
 - Run generated starter CI and publish workflows through `./gradlew check`
 - Harden starter and example Docker runtime images to run as a non-root user

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 This repo is an internal starter candidate. It is ready for controlled pilot adoption, not broad platform-product rollout.
 
-Use `docs/adoption/promotion-brief.md` as the adoption pitch and `docs/releases/version-policy.md` as the dependency baseline. The current stable line remains Java 21 plus Spring Boot 3.5.x while the Boot 4 / Java 25 migration is handled as a separate modernization tranche.
+Use `docs/adoption/promotion-brief.md` as the adoption pitch and `docs/releases/version-policy.md` as the dependency baseline. The current stable line is Java 21 plus Spring Boot 4.1.0.
 
 The default path is `mvc-jpa`. `webflux-r2dbc` remains the supported advanced variant for teams with a real reactive requirement. Optional integrations live under `examples/` and are intentionally outside the starter contract.
 
 ## Starter Contract
 
 Every starter variant should provide:
-- Java 21 and the maintained Spring Boot 3.5.x line
+- Java 21 and the maintained Spring Boot 4.1.x line
 - PostgreSQL plus Flyway
 - Actuator, Prometheus metrics, and OTLP-ready tracing hooks
 - Docker Compose-backed local development plus standalone container smoke coverage
@@ -131,7 +131,7 @@ Default deployment assumptions:
 - no bundled Kafka
 - Actuator-backed health probes
 - HPA support is optional and disabled by default
-- Boot 4 migration is intentionally deferred to the next modernization tranche
+- Java 25 migration remains a separate modernization tranche
 
 ## Governance
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,8 +20,7 @@ Wider rollout requires the adoption gates in `docs/adoption/promotion-brief.md`.
 ## Compatibility Baseline
 
 - Java 21
-- Spring Boot 3.5.x maintained baseline line
-- Spring Boot 4.x migration planned as the next modernization tranche
+- Spring Boot 4.1.x maintained baseline line
 - PostgreSQL as the default persistence contract
 - Kubernetes plus Helm as the supported cloud deployment path
 

--- a/docs/adoption/promotion-brief.md
+++ b/docs/adoption/promotion-brief.md
@@ -25,14 +25,14 @@ Do not sell it as:
 - an authorization framework
 - an eventing framework
 - a service mesh strategy
-- a Boot 4 migration solution
+- a Java runtime migration solution
 - a domain architecture template
 
 ## Promotion Message
 
 The honest pitch:
 
-> This starter gives teams a repeatable Spring service baseline with working local development, tests, container packaging, Helm scaffolding, and release hygiene. It is ready for pilot services. Wider adoption depends on pilot evidence and the Boot 4 / Java 25 modernization tranche.
+> This starter gives teams a repeatable Spring Boot 4.1 service baseline with working local development, tests, container packaging, Helm scaffolding, and release hygiene. It is ready for pilot services. Wider adoption depends on pilot evidence and a later Java 25 modernization tranche.
 
 ## Adoption Rules
 
@@ -51,7 +51,7 @@ Before this becomes the default starter for more than pilot teams:
 3. Generated `mvc-jpa` and `webflux-r2dbc` services must pass `check`, Docker Compose validation, smoke tests, and Helm rendering in CI.
 4. Generated services must publish SBOM artifacts through the CI workflow.
 5. Container images must run as a non-root user by default.
-6. The Boot 4 / Java 25 branch must produce at least one green generated service before the default line changes.
+6. Java 25 must produce at least one green generated service before the Java baseline changes.
 7. Security posture must be explicit: either a starter security baseline is added or the repo documents why service-level auth remains outside the starter contract.
 
 ## Evidence Contract
@@ -75,6 +75,6 @@ Priority order:
 
 1. Finish pilot adoption and collect evidence.
 2. Add an explicit security/auth stance.
-3. Run the Boot 4 / Java 25 modernization tranche.
+3. Run the Java 25 modernization tranche when pilot evidence supports it.
 4. Add OpenAPI generation once the API shape is stable.
 5. Add stricter code quality gates after pilot feedback confirms they will not create busywork.

--- a/docs/adr/ADR-003-2026-modernization-tranches.md
+++ b/docs/adr/ADR-003-2026-modernization-tranches.md
@@ -1,19 +1,19 @@
 # ADR-003: 2026 Modernization Tranches
 
 ## Status
-Accepted
+Superseded
 
 ## Context
-The starter repository needs modernization without breaking its internal golden path through an unmanaged jump to Spring Boot 4. The immediate gaps are dependency drift, variant contract drift, outdated local development conventions, and insufficient deployment hardening.
+The starter repository needed modernization without breaking its internal golden path through an unmanaged jump to Spring Boot 4. The immediate gaps were dependency drift, variant contract drift, outdated local development conventions, and insufficient deployment hardening.
 
 ## Decision
-- Stabilize the repository on the latest maintained Spring Boot `3.5.x` line first.
-- Standardize both starter variants on RFC `9457` problem details before attempting a major-version migration.
+- Stabilized the repository on the maintained Spring Boot `3.5.x` line first.
+- Standardized both starter variants on RFC `9457` problem details before attempting a major-version migration.
 - Make `compose.yaml` plus Spring Boot development services the preferred `bootRun` workflow while keeping `docker-compose.yml` for standalone container smoke validation.
 - Keep `mvc-jpa` as the golden path and `webflux-r2dbc` as the advanced supported variant.
-- Defer API versioning design until the dedicated Spring Boot 4 tranche.
+- Deferred API versioning design until after the Spring Boot 4 tranche.
 
 ## Consequences
 - Generated services inherit a consistent API error contract across both variants.
 - Local development and CI validation both cover the `bootRun` path and the full container path.
-- Boot 4 work remains an explicit follow-up tranche rather than an unbounded refactor folded into routine maintenance.
+- Boot 4 work moved into the current baseline after the dedicated Spring Boot 4.1 migration work began.

--- a/docs/adr/ADR-004-promotion-and-supply-chain-baseline.md
+++ b/docs/adr/ADR-004-promotion-and-supply-chain-baseline.md
@@ -23,4 +23,4 @@ The starter is strong enough for controlled adoption but not mature enough to be
 - Promotion claims are backed by generated output, not only documentation.
 - Teams get better build-chain visibility on day one.
 - The repo remains honest about what it does not solve: authorization, runtime scanning, artifact signing, and production security controls still require explicit platform ownership.
-- Boot 4 / Java 25 remains a separate modernization tranche rather than an accidental breaking change folded into promotion work.
+- Java 25 remains a separate modernization tranche rather than an accidental breaking change folded into promotion work.

--- a/docs/releases/version-policy.md
+++ b/docs/releases/version-policy.md
@@ -6,34 +6,34 @@ This document keeps the starter from drifting into accidental legacy. Dependency
 
 ## Current Baseline
 
-As of April 24, 2026:
+As of July 5, 2026:
 
 | Layer | Default | Status |
 | --- | --- | --- |
 | Java | 21 | Stable starter baseline |
-| Spring Boot | 3.5.x | Stable starter baseline |
-| Gradle | 9.4.1 | Current wrapper and Docker builder baseline |
+| Spring Boot | 4.1.0 | Stable starter baseline |
+| Gradle | 9.6.1 | Current wrapper and Docker builder baseline |
 | PostgreSQL | 17 | Local and integration-test baseline |
-| Boot 4 / Java 25 | Migration tranche | Not the default yet |
+| Java 25 | Future migration tranche | Not the default yet |
 
 References:
 
-- Spring Boot 4.0.6 was released on April 23, 2026: https://spring.io/blog/2026/04/23/spring-boot-4-0-6-available-now
+- Spring Boot 4.1.0 was released on June 10, 2026: https://spring.io/blog/2026/06/10/spring-boot-4
 - Oracle announced Java 25 on September 16, 2025 with long-term support: https://www.oracle.com/news/announcement/oracle-releases-java-25-2025-09-16
-- Gradle 9.4.1 was published on March 19, 2026: https://gradle.org/releases
+- Gradle 9.6.1 was published on June 26, 2026: https://gradle.org/releases
 
 ## Baseline Rules
 
 - Patch updates on the current stable line should be applied promptly when generated starters remain green.
-- Minor or major platform changes require a modernization tranche, not a casual version bump.
+- Minor or major platform changes require generated starter validation, not a casual version bump.
 - Java baseline changes require generated service tests, smoke tests, Docker builds, and Helm rendering to pass.
-- Spring Boot major-version changes require an ADR update, migration notes, and at least one pilot-generated service.
+- Spring Boot major-version changes require migration notes and generated starter validation.
 - Gradle wrapper and Docker builder image versions should stay aligned.
 - Examples should follow the starter baseline unless an example has a documented integration constraint.
 
 ## Stable Line
 
-The stable line remains Java 21 and Spring Boot 3.5.x until the Boot 4 / Java 25 tranche proves:
+The stable line is Java 21 and Spring Boot 4.1.0. It remains stable only while:
 
 - generated `mvc-jpa` and `webflux-r2dbc` services compile and test cleanly
 - Docker images build and run
@@ -44,9 +44,9 @@ The stable line remains Java 21 and Spring Boot 3.5.x until the Boot 4 / Java 25
 
 ## Next Line
 
-The next line is Java 25 plus Spring Boot 4.x.
+The next line is Java 25 on the Spring Boot 4.x baseline.
 
-The migration branch should be treated as a product decision, not a dependency chore. It should produce migration notes for generated services, call out breaking changes, and define whether Java 25 becomes required or optional.
+The Java 25 migration should be treated as a product decision, not a dependency chore. It should produce migration notes for generated services, call out breaking changes, and define whether Java 25 becomes required or optional.
 
 ## Dependency Review Rules
 

--- a/examples/binance-websocket/build.gradle
+++ b/examples/binance-websocket/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/examples/binance-websocket/src/main/java/tech/dtkmn/examples/binancewebsocket/service/SpotMessageHandler.java
+++ b/examples/binance-websocket/src/main/java/tech/dtkmn/examples/binancewebsocket/service/SpotMessageHandler.java
@@ -1,10 +1,10 @@
 package tech.dtkmn.examples.binancewebsocket.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Service

--- a/examples/kafka-basic/build.gradle
+++ b/examples/kafka-basic/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 }
 
 tasks.named('test') {

--- a/examples/kafka-basic/src/test/java/tech/dtkmn/examples/kafkabasic/controller/MessageControllerTest.java
+++ b/examples/kafka-basic/src/test/java/tech/dtkmn/examples/kafkabasic/controller/MessageControllerTest.java
@@ -3,7 +3,7 @@ package tech.dtkmn.examples.kafkabasic.controller;
 import tech.dtkmn.examples.kafkabasic.service.MessageProducerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/examples/kafka-streams/build.gradle
+++ b/examples/kafka-streams/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/variants/mvc-jpa/template/SUPPORT.md
+++ b/variants/mvc-jpa/template/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## Baseline
 - Java 21
-- Spring Boot 3.5.x stable line
+- Spring Boot 4.1.x stable line
 - PostgreSQL
 - Kubernetes + Helm deployment path
 

--- a/variants/mvc-jpa/template/build.gradle
+++ b/variants/mvc-jpa/template/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.cyclonedx.bom' version '3.2.4'
 }
@@ -51,6 +51,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'

--- a/variants/mvc-jpa/template/src/test/java/__PACKAGE_PATH__/web/CustomerApiIntegrationTest.java
+++ b/variants/mvc-jpa/template/src/test/java/__PACKAGE_PATH__/web/CustomerApiIntegrationTest.java
@@ -2,9 +2,9 @@ package __PACKAGE_NAME__.web;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.PostgreSQLContainer;

--- a/variants/mvc-jpa/template/src/test/java/__PACKAGE_PATH__/web/CustomerControllerTest.java
+++ b/variants/mvc-jpa/template/src/test/java/__PACKAGE_PATH__/web/CustomerControllerTest.java
@@ -5,7 +5,7 @@ import __PACKAGE_NAME__.service.CustomerService;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;

--- a/variants/webflux-r2dbc/template/SUPPORT.md
+++ b/variants/webflux-r2dbc/template/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## Baseline
 - Java 21
-- Spring Boot 3.5.x stable line
+- Spring Boot 4.1.x stable line
 - PostgreSQL
 - Kubernetes + Helm deployment path
 

--- a/variants/webflux-r2dbc/template/build.gradle
+++ b/variants/webflux-r2dbc/template/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '4.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'org.cyclonedx.bom' version '3.2.4'
 }
@@ -52,6 +52,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/variants/webflux-r2dbc/template/src/test/java/__PACKAGE_PATH__/web/CustomerApiIntegrationTest.java
+++ b/variants/webflux-r2dbc/template/src/test/java/__PACKAGE_PATH__/web/CustomerApiIntegrationTest.java
@@ -2,9 +2,9 @@ package __PACKAGE_NAME__.web;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.testcontainers.containers.PostgreSQLContainer;

--- a/variants/webflux-r2dbc/template/src/test/java/__PACKAGE_PATH__/web/CustomerControllerTest.java
+++ b/variants/webflux-r2dbc/template/src/test/java/__PACKAGE_PATH__/web/CustomerControllerTest.java
@@ -4,7 +4,7 @@ import __PACKAGE_NAME__.domain.CustomerResponse;
 import __PACKAGE_NAME__.service.CustomerService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;


### PR DESCRIPTION
This pull request upgrades the Spring service starter and all example projects from Spring Boot 3.5.x to Spring Boot 4.1.0, and aligns the Gradle baseline to 9.6.1. It updates documentation, dependency versions, and test annotations to reflect the new baseline, and clarifies the modernization plan by decoupling Java 25 migration from the Spring Boot upgrade. The changes ensure that generated starters and examples are validated against the new platform versions and that documentation is consistent with the current state.

**Platform and Dependency Upgrades:**

* Upgraded all starter templates and example projects to use Spring Boot 4.1.0 (was 3.5.x/3.5.15) and Gradle 9.6.1 (was 9.4.1), updating `build.gradle` files and related documentation to match. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL23-R23) [[2]](diffhunk://#diff-e9a75fe139a3966ab17552618ab7afc7d059e824662e33a1f368b3baf60e0882L3-R3) [[3]](diffhunk://#diff-e582b253f56d265f56df5512b0862241fd8098b80c3ce73f2b95d6fea1bcdf68L3-R3) [[4]](diffhunk://#diff-8711b034e56da97731a13cfb840dfd292d3229811d1151d6e9e9f5dd633a9e32L3-R3) [[5]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eL4-R4) [[6]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eL4-R4) [[7]](diffhunk://#diff-3dfc20f1c3bf4aff65944cd7a334c3d31b2f236f745feda0ff62259dee0a945fL9-R36)
* Updated test dependencies and annotations to match new Spring Boot 4.1 module structure (e.g., using `org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest` and `org.springframework.boot.webflux.test.autoconfigure.WebFluxTest`). [[1]](diffhunk://#diff-60cb27557150b579fd30d4e38e58686eeec0d8fbd7575b5ae4fce59dc5c5c32aL6-R6) [[2]](diffhunk://#diff-300f344ea5aff1f5be5ed16db6a53a7b5c78b47c4f6216f67d74592192c41b49L8-R8) [[3]](diffhunk://#diff-88409b5651216295a61d20f899033b67b77f6e1a97ad47974b2d2120c8110224L5-R7) [[4]](diffhunk://#diff-c8a68f45b57e465ed13cce32a434b04f2514f991dd67efa88d6459d0b6f4c6aaL7-R7) [[5]](diffhunk://#diff-77fa7534b55e19c9ff8d5e6a7341b5d0c3338479e1bf5539868130d0006cc2ceL5-R7)

**Documentation and Policy Updates:**

* Updated all documentation to reflect the new baseline: Java 21 plus Spring Boot 4.1.x is now the stable line, and Java 25 migration is a future, separate modernization tranche. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R16) [[2]](diffhunk://#diff-c5fe610b0215b144474106251cab954f8af55fe26cbd5d2265fd6ca19109c97bL23-R23) [[3]](diffhunk://#diff-b4bfaafd1d81c4d542b0fad5585cb42b73033c6507ab1b219e22183261297621L5-R5) [[4]](diffhunk://#diff-b4bfaafd1d81c4d542b0fad5585cb42b73033c6507ab1b219e22183261297621L5-R5) [[5]](diffhunk://#diff-3dfc20f1c3bf4aff65944cd7a334c3d31b2f236f745feda0ff62259dee0a945fL9-R36) [[6]](diffhunk://#diff-3dfc20f1c3bf4aff65944cd7a334c3d31b2f236f745feda0ff62259dee0a945fL47-R49)
* Clarified that the Java 25 migration is decoupled from the Spring Boot upgrade, and updated modernization plan and ADRs to reflect the completed Spring Boot 4.1 migration. [[1]](diffhunk://#diff-4a644517774cfadcb6e936620e095f9f8c4237b45447c2ef96c4acb1eea6c3acL4-R19) [[2]](diffhunk://#diff-6bf4d7459c7efd5ce0205a478d5e2de358b8afeaaaa462866a453304eee32283L26-R26) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L134-R134) [[4]](diffhunk://#diff-ba1ea41f6c2730b9aac971e83c8940b13153fd44309290c5c23d08266a43be0bL28-R35) [[5]](diffhunk://#diff-ba1ea41f6c2730b9aac971e83c8940b13153fd44309290c5c23d08266a43be0bL54-R54) [[6]](diffhunk://#diff-ba1ea41f6c2730b9aac971e83c8940b13153fd44309290c5c23d08266a43be0bL78-R78)

**Example and Starter Improvements:**

* Added missing test dependencies for new Spring Boot 4.1 test modules (e.g., `spring-boot-starter-webmvc-test`, `spring-boot-starter-webflux-test`). [[1]](diffhunk://#diff-e582b253f56d265f56df5512b0862241fd8098b80c3ce73f2b95d6fea1bcdf68R31) [[2]](diffhunk://#diff-bc981d5fd1750206d0a066224ced39ddef53026335f6d64730564e9ca3c26d5eR54) [[3]](diffhunk://#diff-7f9d707d6edb24dd874dcf8a9832b76ae3500c71ec349cda9473312c553de09eR55)
* Updated example code to use relocated Jackson imports compatible with Spring Boot 4.1.

These changes ensure the starter and all examples are validated and ready for pilot adoption on the latest Spring Boot and Gradle baselines, with clear documentation and migration guidance.